### PR TITLE
Initial Upstream

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -31,4 +31,4 @@ repos:
       - id: terraform_tflint
         args:
           - --args=--config=__GIT_WORKING_DIR__/.tflint.hcl
-        exclude: "context.tf$"
+        exclude: "(context|providers).tf$"

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 -include $(shell curl -sSL -o .build-harness "https://cloudposse.tools/build-harness"; echo .build-harness)
 
-all: init readme
+all: init docs/terraform.md readme
 
 test::
 	@echo "🚀 Starting tests..."

--- a/README.md
+++ b/README.md
@@ -66,24 +66,10 @@ components:
 
 If you have a Transit Gateway Route Table, you can create an association with the Transit Gateway VPC Attachment. This is necessary for attachments in the _same account_ as the Transit Gateway Route Table. For example, if you have a Transit Gateway Route Table in the _core_ account, you will need to create an association for each of the VPCs in the _core_ account.
 
+For any connected VPC to this account, you need to create an association with the Transit Gateway Route Table.
+
 ```yaml
 # core-network stack
-components:
-  terraform:
-    tgw/attachment:
-      vars:
-        enabled: true
-        transit_gateway_id: !terraform.output tgw/hub core-use1-network transit_gateway_id
-        transit_gateway_route_table_id: !terraform.output tgw/hub core-use1-network transit_gateway_route_table_id
-        create_transit_gateway_route_table_association: true
-```
-
-#### Additional Associations
-
-If you have peered connections to other VPCs, you may need to create associations for each of those VPCs. You typically need these associations created in the same account as the peered Transit Gateway.
-
-```yaml
-# core-usw2-network stack (example alternative region)
 components:
   terraform:
     tgw/attachment:
@@ -93,7 +79,7 @@ components:
         transit_gateway_route_table_id: !terraform.output tgw/hub core-usw2-network transit_gateway_route_table_id
         create_transit_gateway_route_table_association: true
 
-        # Add associations for the peered VPCs' Transit Gateway Attachments
+        # Include association for each of the connected account
         additional_associations:
           - attachment_id: !terraform.output tgw/attachment plat-usw2-dev transit_gateway_attachment_id
             route_table_id: !terraform.output tgw/hub transit_gateway_route_table_id

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
+
+
 <!-- markdownlint-disable -->
-<a href="https://cpco.io/homepage"><img src=".github/banner.png?raw=true" alt="Project Banner"/></a><br/>
+<a href="https://cpco.io/homepage"><img src="https://github.com/cloudposse-terraform-components/aws-tgw-attachment/blob/main/.github/banner.png?raw=true" alt="Project Banner"/></a><br/>
     <p align="right">
 <a href="https://github.com/cloudposse-terraform-components/template/releases/latest"><img src="https://img.shields.io/github/release/cloudposse-terraform-components/template.svg?style=for-the-badge" alt="Latest Release"/></a><a href="https://slack.cloudposse.com"><img src="https://slack.cloudposse.com/for-the-badge.svg" alt="Slack Community"/></a></p>
 <!-- markdownlint-restore -->
@@ -25,26 +27,25 @@
 
 -->
 
-Description of this component
+This component creates a Transit Gateway VPC Attachment and optionally creates an association with a Transit Gateway Route Table.
 
 
----
-> [!NOTE]
-> This project is part of Cloud Posse's comprehensive ["SweetOps"](https://cpco.io/homepage?utm_source=github&utm_medium=readme&utm_campaign=cloudposse-terraform-components/template&utm_content=) approach towards DevOps.
-> <details><summary><strong>Learn More</strong></summary>
+> [!TIP]
+> #### 👽 Use Atmos with Terraform
+> Cloud Posse uses [`atmos`](https://atmos.tools) to easily orchestrate multiple environments using Terraform. <br/>
+> Works with [Github Actions](https://atmos.tools/integrations/github-actions/), [Atlantis](https://atmos.tools/integrations/atlantis), or [Spacelift](https://atmos.tools/integrations/spacelift).
 >
-> It's 100% Open Source and licensed under the [APACHE2](LICENSE).
->
-> </details>
+> <details>
+> <summary><strong>Watch demo of using Atmos with Terraform</strong></summary>
+> <img src="https://github.com/cloudposse/atmos/blob/main/docs/demo.gif?raw=true"/><br/>
+> <i>Example of running <a href="https://atmos.tools"><code>atmos</code></a> to manage infrastructure from our <a href="https://atmos.tools/quick-start/">Quick Start</a> tutorial.</i>
+> </detalis>
 
-<a href="https://cloudposse.com/readme/header/link?utm_source=github&utm_medium=readme&utm_campaign=cloudposse-terraform-components/template&utm_content=readme_header_link"><img src="https://cloudposse.com/readme/header/img"/></a>
 
 
 
 
 ## Usage
-
-
 
 **Stack Level**: Regional or Test47
 
@@ -53,195 +54,55 @@ Here's an example snippet for how to use this component.
 ```yaml
 components:
   terraform:
-    foo:
+    tgw/attachment:
       vars:
         enabled: true
+        transit_gateway_id: !terraform.output tgw/hub core-use1-network transit_gateway_id
+        transit_gateway_route_table_id: !terraform.output tgw/hub core-use1-network transit_gateway_route_table_id
+        create_transit_gateway_route_table_association: false
 ```
 
+#### Transit Gateway Route Table Association
 
+If you have a Transit Gateway Route Table, you can create an association with the Transit Gateway VPC Attachment. This is necessary for attachments in the _same account_ as the Transit Gateway Route Table. For example, if you have a Transit Gateway Route Table in the _core_ account, you will need to create an association for each of the VPCs in the _core_ account.
 
-
-
-
-<!-- markdownlint-disable -->
-## Requirements
-
-| Name | Version |
-|------|---------|
-| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.0.0 |
-
-## Providers
-
-No providers.
-
-## Modules
-
-| Name | Source | Version |
-|------|--------|---------|
-| <a name="module_this"></a> [this](#module\_this) | cloudposse/label/null | 0.25.0 |
-
-## Resources
-
-No resources.
-
-## Inputs
-
-| Name | Description | Type | Default | Required |
-|------|-------------|------|---------|:--------:|
-| <a name="input_additional_tag_map"></a> [additional\_tag\_map](#input\_additional\_tag\_map) | Additional key-value pairs to add to each map in `tags_as_list_of_maps`. Not added to `tags` or `id`.<br/>This is for some rare cases where resources want additional configuration of tags<br/>and therefore take a list of maps with tag key, value, and additional configuration. | `map(string)` | `{}` | no |
-| <a name="input_attributes"></a> [attributes](#input\_attributes) | ID element. Additional attributes (e.g. `workers` or `cluster`) to add to `id`,<br/>in the order they appear in the list. New attributes are appended to the<br/>end of the list. The elements of the list are joined by the `delimiter`<br/>and treated as a single ID element. | `list(string)` | `[]` | no |
-| <a name="input_context"></a> [context](#input\_context) | Single object for setting entire context at once.<br/>See description of individual variables for details.<br/>Leave string and numeric variables as `null` to use default value.<br/>Individual variable settings (non-null) override settings in context object,<br/>except for attributes, tags, and additional\_tag\_map, which are merged. | `any` | <pre>{<br/>  "additional_tag_map": {},<br/>  "attributes": [],<br/>  "delimiter": null,<br/>  "descriptor_formats": {},<br/>  "enabled": true,<br/>  "environment": null,<br/>  "id_length_limit": null,<br/>  "label_key_case": null,<br/>  "label_order": [],<br/>  "label_value_case": null,<br/>  "labels_as_tags": [<br/>    "unset"<br/>  ],<br/>  "name": null,<br/>  "namespace": null,<br/>  "regex_replace_chars": null,<br/>  "stage": null,<br/>  "tags": {},<br/>  "tenant": null<br/>}</pre> | no |
-| <a name="input_delimiter"></a> [delimiter](#input\_delimiter) | Delimiter to be used between ID elements.<br/>Defaults to `-` (hyphen). Set to `""` to use no delimiter at all. | `string` | `null` | no |
-| <a name="input_descriptor_formats"></a> [descriptor\_formats](#input\_descriptor\_formats) | Describe additional descriptors to be output in the `descriptors` output map.<br/>Map of maps. Keys are names of descriptors. Values are maps of the form<br/>`{<br/>   format = string<br/>   labels = list(string)<br/>}`<br/>(Type is `any` so the map values can later be enhanced to provide additional options.)<br/>`format` is a Terraform format string to be passed to the `format()` function.<br/>`labels` is a list of labels, in order, to pass to `format()` function.<br/>Label values will be normalized before being passed to `format()` so they will be<br/>identical to how they appear in `id`.<br/>Default is `{}` (`descriptors` output will be empty). | `any` | `{}` | no |
-| <a name="input_enabled"></a> [enabled](#input\_enabled) | Set to false to prevent the module from creating any resources | `bool` | `null` | no |
-| <a name="input_environment"></a> [environment](#input\_environment) | ID element. Usually used for region e.g. 'uw2', 'us-west-2', OR role 'prod', 'staging', 'dev', 'UAT' | `string` | `null` | no |
-| <a name="input_id_length_limit"></a> [id\_length\_limit](#input\_id\_length\_limit) | Limit `id` to this many characters (minimum 6).<br/>Set to `0` for unlimited length.<br/>Set to `null` for keep the existing setting, which defaults to `0`.<br/>Does not affect `id_full`. | `number` | `null` | no |
-| <a name="input_label_key_case"></a> [label\_key\_case](#input\_label\_key\_case) | Controls the letter case of the `tags` keys (label names) for tags generated by this module.<br/>Does not affect keys of tags passed in via the `tags` input.<br/>Possible values: `lower`, `title`, `upper`.<br/>Default value: `title`. | `string` | `null` | no |
-| <a name="input_label_order"></a> [label\_order](#input\_label\_order) | The order in which the labels (ID elements) appear in the `id`.<br/>Defaults to ["namespace", "environment", "stage", "name", "attributes"].<br/>You can omit any of the 6 labels ("tenant" is the 6th), but at least one must be present. | `list(string)` | `null` | no |
-| <a name="input_label_value_case"></a> [label\_value\_case](#input\_label\_value\_case) | Controls the letter case of ID elements (labels) as included in `id`,<br/>set as tag values, and output by this module individually.<br/>Does not affect values of tags passed in via the `tags` input.<br/>Possible values: `lower`, `title`, `upper` and `none` (no transformation).<br/>Set this to `title` and set `delimiter` to `""` to yield Pascal Case IDs.<br/>Default value: `lower`. | `string` | `null` | no |
-| <a name="input_labels_as_tags"></a> [labels\_as\_tags](#input\_labels\_as\_tags) | Set of labels (ID elements) to include as tags in the `tags` output.<br/>Default is to include all labels.<br/>Tags with empty values will not be included in the `tags` output.<br/>Set to `[]` to suppress all generated tags.<br/>**Notes:**<br/>  The value of the `name` tag, if included, will be the `id`, not the `name`.<br/>  Unlike other `null-label` inputs, the initial setting of `labels_as_tags` cannot be<br/>  changed in later chained modules. Attempts to change it will be silently ignored. | `set(string)` | <pre>[<br/>  "default"<br/>]</pre> | no |
-| <a name="input_name"></a> [name](#input\_name) | ID element. Usually the component or solution name, e.g. 'app' or 'jenkins'.<br/>This is the only ID element not also included as a `tag`.<br/>The "name" tag is set to the full `id` string. There is no tag with the value of the `name` input. | `string` | `null` | no |
-| <a name="input_namespace"></a> [namespace](#input\_namespace) | ID element. Usually an abbreviation of your organization name, e.g. 'eg' or 'cp', to help ensure generated IDs are globally unique | `string` | `null` | no |
-| <a name="input_regex_replace_chars"></a> [regex\_replace\_chars](#input\_regex\_replace\_chars) | Terraform regular expression (regex) string.<br/>Characters matching the regex will be removed from the ID elements.<br/>If not set, `"/[^a-zA-Z0-9-]/"` is used to remove all characters other than hyphens, letters and digits. | `string` | `null` | no |
-| <a name="input_stage"></a> [stage](#input\_stage) | ID element. Usually used to indicate role, e.g. 'prod', 'staging', 'source', 'build', 'test', 'deploy', 'release' | `string` | `null` | no |
-| <a name="input_tags"></a> [tags](#input\_tags) | Additional tags (e.g. `{'BusinessUnit': 'XYZ'}`).<br/>Neither the tag keys nor the tag values will be modified by this module. | `map(string)` | `{}` | no |
-| <a name="input_tenant"></a> [tenant](#input\_tenant) | ID element \_(Rarely used, not included by default)\_. A customer identifier, indicating who this instance of a resource is for | `string` | `null` | no |
-
-## Outputs
-
-| Name | Description |
-|------|-------------|
-| <a name="output_mock"></a> [mock](#output\_mock) | Mock output example for the Cloud Posse Terraform component template |
-<!-- markdownlint-restore -->
-
-
-## Related Projects
-
-Check out these related projects.
-
-- [Cloud Posse Terraform Modules](https://docs.cloudposse.com/modules/) - Our collection of reusable Terraform modules used by our reference architectures.
-- [Atmos](https://atmos.tools) - Atmos is like docker-compose but for your infrastructure
-
-
-## References
-
-For additional context, refer to some of these links.
-
-- [Cloud Posse Documentation](https://docs.cloudposse.com) - Complete documentation for the Cloud Posse solution
-- [Reference Architectures](https://cloudposse.com/) - Launch effortlessly with our turnkey reference architectures, built either by your team or ours.
-
-
-## ✨ Contributing
-
-This project is under active development, and we encourage contributions from our community.
-Many thanks to our outstanding contributors:
-
-<a href="https://github.com/cloudposse-terraform-components/template/graphs/contributors">
-  <img src="https://contrib.rocks/image?repo=cloudposse-terraform-components/template&max=24" />
-</a>
-
-### 🐛 Bug Reports & Feature Requests
-
-Please use the [issue tracker](https://github.com/cloudposse-terraform-components/template/issues) to report any bugs or file feature requests.
-
-### 💻 Developing
-
-If you are interested in being a contributor and want to get involved in developing this project or help out with Cloud Posse's other projects, we would love to hear from you!
-Hit us up in [Slack](https://cpco.io/slack?utm_source=github&utm_medium=readme&utm_campaign=cloudposse-terraform-components/template&utm_content=slack), in the `#cloudposse` channel.
-
-In general, PRs are welcome. We follow the typical "fork-and-pull" Git workflow.
- 1. Review our [Code of Conduct](https://github.com/cloudposse-terraform-components/template/?tab=coc-ov-file#code-of-conduct) and [Contributor Guidelines](https://github.com/cloudposse/.github/blob/main/CONTRIBUTING.md).
- 2. **Fork** the repo on GitHub
- 3. **Clone** the project to your own machine
- 4. **Commit** changes to your own branch
- 5. **Push** your work back up to your fork
- 6. Submit a **Pull Request** so that we can review your changes
-
-**NOTE:** Be sure to merge the latest changes from "upstream" before making a pull request!
-
-### 🌎 Slack Community
-
-Join our [Open Source Community](https://cpco.io/slack?utm_source=github&utm_medium=readme&utm_campaign=cloudposse-terraform-components/template&utm_content=slack) on Slack. It's **FREE** for everyone! Our "SweetOps" community is where you get to talk with others who share a similar vision for how to rollout and manage infrastructure. This is the best place to talk shop, ask questions, solicit feedback, and work together as a community to build totally *sweet* infrastructure.
-
-### 📰 Newsletter
-
-Sign up for [our newsletter](https://cpco.io/newsletter?utm_source=github&utm_medium=readme&utm_campaign=cloudposse-terraform-components/template&utm_content=newsletter) and join 3,000+ DevOps engineers, CTOs, and founders who get insider access to the latest DevOps trends, so you can always stay in the know.
-Dropped straight into your Inbox every week — and usually a 5-minute read.
-
-### 📆 Office Hours <a href="https://cloudposse.com/office-hours?utm_source=github&utm_medium=readme&utm_campaign=cloudposse-terraform-components/template&utm_content=office_hours"><img src="https://img.cloudposse.com/fit-in/200x200/https://cloudposse.com/wp-content/uploads/2019/08/Powered-by-Zoom.png" align="right" /></a>
-
-[Join us every Wednesday via Zoom](https://cloudposse.com/office-hours?utm_source=github&utm_medium=readme&utm_campaign=cloudposse-terraform-components/template&utm_content=office_hours) for your weekly dose of insider DevOps trends, AWS news and Terraform insights, all sourced from our SweetOps community, plus a _live Q&A_ that you can’t find anywhere else.
-It's **FREE** for everyone!
-
-## About
-
-This project is maintained by <a href="https://cpco.io/homepage?utm_source=github&utm_medium=readme&utm_campaign=cloudposse-terraform-components/template&utm_content=">Cloud Posse, LLC</a>.
-<a href="https://cpco.io/homepage?utm_source=github&utm_medium=readme&utm_campaign=cloudposse-terraform-components/template&utm_content="><img src="https://cloudposse.com/logo-300x69.svg" align="right" /></a>
-
-We are a [**DevOps Accelerator**](https://cpco.io/commercial-support?utm_source=github&utm_medium=readme&utm_campaign=cloudposse-terraform-components/template&utm_content=commercial_support) for funded startups and enterprises.
-Use our ready-to-go terraform architecture blueprints for AWS to get up and running quickly.
-We build it with you. You own everything. Your team wins. Plus, we stick around until you succeed.
-
-<a href="https://cpco.io/commercial-support?utm_source=github&utm_medium=readme&utm_campaign=cloudposse-terraform-components/template&utm_content=commercial_support"><img alt="Learn More" src="https://img.shields.io/badge/learn%20more-success.svg?style=for-the-badge"/></a>
-
-*Your team can operate like a pro today.*
-
-Ensure that your team succeeds by using our proven process and turnkey blueprints. Plus, we stick around until you succeed.
-
-<details>
-  <summary>📚 <strong>See What's Included</strong></summary>
-
-- **Reference Architecture.** You'll get everything you need from the ground up built using 100% infrastructure as code.
-- **Deployment Strategy.** You'll have a battle-tested deployment strategy using GitHub Actions that's automated and repeatable.
-- **Site Reliability Engineering.** You'll have total visibility into your apps and microservices.
-- **Security Baseline.** You'll have built-in governance with accountability and audit logs for all changes.
-- **GitOps.** You'll be able to operate your infrastructure via Pull Requests.
-- **Training.** You'll receive hands-on training so your team can operate what we build.
-- **Questions.** You'll have a direct line of communication between our teams via a Shared Slack channel.
-- **Troubleshooting.** You'll get help to triage when things aren't working.
-- **Code Reviews.** You'll receive constructive feedback on Pull Requests.
-- **Bug Fixes.** We'll rapidly work with you to fix any bugs in our projects.
-</details>
-
-<a href="https://cloudposse.com/readme/commercial-support/link?utm_source=github&utm_medium=readme&utm_campaign=cloudposse-terraform-components/template&utm_content=readme_commercial_support_link"><img src="https://cloudposse.com/readme/commercial-support/img"/></a>
-## License
-
-<a href="https://opensource.org/licenses/Apache-2.0"><img src="https://img.shields.io/badge/License-Apache%202.0-blue.svg?style=for-the-badge" alt="License"></a>
-
-<details>
-<summary>Preamble to the Apache License, Version 2.0</summary>
-<br/>
-<br/>
-
-
-
-```text
-Licensed to the Apache Software Foundation (ASF) under one
-or more contributor license agreements.  See the NOTICE file
-distributed with this work for additional information
-regarding copyright ownership.  The ASF licenses this file
-to you under the Apache License, Version 2.0 (the
-"License"); you may not use this file except in compliance
-with the License.  You may obtain a copy of the License at
-
-  https://www.apache.org/licenses/LICENSE-2.0
-
-Unless required by applicable law or agreed to in writing,
-software distributed under the License is distributed on an
-"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
-KIND, either express or implied.  See the License for the
-specific language governing permissions and limitations
-under the License.
+```yaml
+# core-network stack
+components:
+  terraform:
+    tgw/attachment:
+      vars:
+        enabled: true
+        transit_gateway_id: !terraform.output tgw/hub core-use1-network transit_gateway_id
+        transit_gateway_route_table_id: !terraform.output tgw/hub core-use1-network transit_gateway_route_table_id
+        create_transit_gateway_route_table_association: true
 ```
-</details>
 
-## Trademarks
+#### Additional Associations
 
-All other trademarks referenced herein are the property of their respective owners.
----
-Copyright © 2017-2024 [Cloud Posse, LLC](https://cpco.io/copyright)
+If you have peered connections to other VPCs, you may need to create associations for each of those VPCs. You typically need these associations created in the same account as the peered Transit Gateway.
 
+```yaml
+# core-usw2-network stack (example alternative region)
+components:
+  terraform:
+    tgw/attachment:
+      vars:
+        enabled: true
+        transit_gateway_id: !terraform.output tgw/hub core-usw2-network transit_gateway_id
+        transit_gateway_route_table_id: !terraform.output tgw/hub core-usw2-network transit_gateway_route_table_id
+        create_transit_gateway_route_table_association: true
 
-<a href="https://cloudposse.com/readme/footer/link?utm_source=github&utm_medium=readme&utm_campaign=cloudposse-terraform-components/template&utm_content=readme_footer_link"><img alt="README footer" src="https://cloudposse.com/readme/footer/img"/></a>
+        # Add associations for the peered VPCs' Transit Gateway Attachments
+        additional_associations:
+          - attachment_id: !terraform.output tgw/attachment plat-usw2-dev transit_gateway_attachment_id
+            route_table_id: !terraform.output tgw/hub transit_gateway_route_table_id
+          - attachment_id: !terraform.output tgw/attachment plat-usw2-prod transit_gateway_attachment_id
+            route_table_id: !terraform.output tgw/hub transit_gateway_route_table_id
+```
 
-<img alt="Beacon" width="0" src="https://ga-beacon.cloudposse.com/UA-76589703-4/cloudposse-terraform-components/template?pixel&cs=github&cm=readme&an=template"/>
+> [!IMPORTANT]
+> In Cloud Posse's examples, we avoid pinning modules to specific versions to prevent discrepancies between the documentation
+> and the latest released versions. However, for your own projects, we strongly advise pinning each module to the exact version
+> you're using. This practice ensures the stability of your infrastructure. Additionally, we recommend implementing a systematic
+> approach for updating versions to avoid unexpected changes.

--- a/README.md
+++ b/README.md
@@ -106,3 +106,175 @@ components:
 > and the latest released versions. However, for your own projects, we strongly advise pinning each module to the exact version
 > you're using. This practice ensures the stability of your infrastructure. Additionally, we recommend implementing a systematic
 > approach for updating versions to avoid unexpected changes.
+
+
+
+
+
+
+
+
+<!-- markdownlint-disable -->
+## Requirements
+
+No requirements.
+
+## Providers
+
+No providers.
+
+## Modules
+
+No modules.
+
+## Resources
+
+No resources.
+
+## Inputs
+
+No inputs.
+
+## Outputs
+
+No outputs.
+<!-- markdownlint-restore -->
+
+
+## Related Projects
+
+Check out these related projects.
+
+- [Cloud Posse Terraform Modules](https://docs.cloudposse.com/modules/) - Our collection of reusable Terraform modules used by our reference architectures.
+- [Atmos](https://atmos.tools) - Atmos is like docker-compose but for your infrastructure
+
+
+## References
+
+For additional context, refer to some of these links.
+
+- [Cloud Posse Documentation](https://docs.cloudposse.com) - Complete documentation for the Cloud Posse solution
+- [Reference Architectures](https://cloudposse.com/) - Launch effortlessly with our turnkey reference architectures, built either by your team or ours.
+
+
+
+> [!TIP]
+> #### Use Terraform Reference Architectures for AWS
+>
+> Use Cloud Posse's ready-to-go [terraform architecture blueprints](https://cloudposse.com/reference-architecture/) for AWS to get up and running quickly.
+>
+> ✅ We build it together with your team.<br/>
+> ✅ Your team owns everything.<br/>
+> ✅ 100% Open Source and backed by fanatical support.<br/>
+>
+> <a href="https://cpco.io/commercial-support?utm_source=github&utm_medium=readme&utm_campaign=cloudposse-terraform-components/aws-tgw-attachment&utm_content=commercial_support"><img alt="Request Quote" src="https://img.shields.io/badge/request%20quote-success.svg?style=for-the-badge"/></a>
+> <details><summary>📚 <strong>Learn More</strong></summary>
+>
+> <br/>
+>
+> Cloud Posse is the leading [**DevOps Accelerator**](https://cpco.io/commercial-support?utm_source=github&utm_medium=readme&utm_campaign=cloudposse-terraform-components/aws-tgw-attachment&utm_content=commercial_support) for funded startups and enterprises.
+>
+> *Your team can operate like a pro today.*
+>
+> Ensure that your team succeeds by using Cloud Posse's proven process and turnkey blueprints. Plus, we stick around until you succeed.
+> #### Day-0:  Your Foundation for Success
+> - **Reference Architecture.** You'll get everything you need from the ground up built using 100% infrastructure as code.
+> - **Deployment Strategy.** Adopt a proven deployment strategy with GitHub Actions, enabling automated, repeatable, and reliable software releases.
+> - **Site Reliability Engineering.** Gain total visibility into your applications and services with Datadog, ensuring high availability and performance.
+> - **Security Baseline.** Establish a secure environment from the start, with built-in governance, accountability, and comprehensive audit logs, safeguarding your operations.
+> - **GitOps.** Empower your team to manage infrastructure changes confidently and efficiently through Pull Requests, leveraging the full power of GitHub Actions.
+>
+> <a href="https://cpco.io/commercial-support?utm_source=github&utm_medium=readme&utm_campaign=cloudposse-terraform-components/aws-tgw-attachment&utm_content=commercial_support"><img alt="Request Quote" src="https://img.shields.io/badge/request%20quote-success.svg?style=for-the-badge"/></a>
+>
+> #### Day-2: Your Operational Mastery
+> - **Training.** Equip your team with the knowledge and skills to confidently manage the infrastructure, ensuring long-term success and self-sufficiency.
+> - **Support.** Benefit from a seamless communication over Slack with our experts, ensuring you have the support you need, whenever you need it.
+> - **Troubleshooting.** Access expert assistance to quickly resolve any operational challenges, minimizing downtime and maintaining business continuity.
+> - **Code Reviews.** Enhance your team’s code quality with our expert feedback, fostering continuous improvement and collaboration.
+> - **Bug Fixes.** Rely on our team to troubleshoot and resolve any issues, ensuring your systems run smoothly.
+> - **Migration Assistance.** Accelerate your migration process with our dedicated support, minimizing disruption and speeding up time-to-value.
+> - **Customer Workshops.** Engage with our team in weekly workshops, gaining insights and strategies to continuously improve and innovate.
+>
+> <a href="https://cpco.io/commercial-support?utm_source=github&utm_medium=readme&utm_campaign=cloudposse-terraform-components/aws-tgw-attachment&utm_content=commercial_support"><img alt="Request Quote" src="https://img.shields.io/badge/request%20quote-success.svg?style=for-the-badge"/></a>
+> </details>
+
+## ✨ Contributing
+
+This project is under active development, and we encourage contributions from our community.
+
+
+
+Many thanks to our outstanding contributors:
+
+<a href="https://github.com/cloudposse-terraform-components/aws-tgw-attachment/graphs/contributors">
+  <img src="https://contrib.rocks/image?repo=cloudposse-terraform-components/aws-tgw-attachment&max=24" />
+</a>
+
+For 🐛 bug reports & feature requests, please use the [issue tracker](https://github.com/cloudposse-terraform-components/aws-tgw-attachment/issues).
+
+In general, PRs are welcome. We follow the typical "fork-and-pull" Git workflow.
+ 1. Review our [Code of Conduct](https://github.com/cloudposse-terraform-components/aws-tgw-attachment/?tab=coc-ov-file#code-of-conduct) and [Contributor Guidelines](https://github.com/cloudposse/.github/blob/main/CONTRIBUTING.md).
+ 2. **Fork** the repo on GitHub
+ 3. **Clone** the project to your own machine
+ 4. **Commit** changes to your own branch
+ 5. **Push** your work back up to your fork
+ 6. Submit a **Pull Request** so that we can review your changes
+
+**NOTE:** Be sure to merge the latest changes from "upstream" before making a pull request!
+
+### 🌎 Slack Community
+
+Join our [Open Source Community](https://cpco.io/slack?utm_source=github&utm_medium=readme&utm_campaign=cloudposse-terraform-components/aws-tgw-attachment&utm_content=slack) on Slack. It's **FREE** for everyone! Our "SweetOps" community is where you get to talk with others who share a similar vision for how to rollout and manage infrastructure. This is the best place to talk shop, ask questions, solicit feedback, and work together as a community to build totally *sweet* infrastructure.
+
+### 📰 Newsletter
+
+Sign up for [our newsletter](https://cpco.io/newsletter?utm_source=github&utm_medium=readme&utm_campaign=cloudposse-terraform-components/aws-tgw-attachment&utm_content=newsletter) and join 3,000+ DevOps engineers, CTOs, and founders who get insider access to the latest DevOps trends, so you can always stay in the know.
+Dropped straight into your Inbox every week — and usually a 5-minute read.
+
+### 📆 Office Hours <a href="https://cloudposse.com/office-hours?utm_source=github&utm_medium=readme&utm_campaign=cloudposse-terraform-components/aws-tgw-attachment&utm_content=office_hours"><img src="https://img.cloudposse.com/fit-in/200x200/https://cloudposse.com/wp-content/uploads/2019/08/Powered-by-Zoom.png" align="right" /></a>
+
+[Join us every Wednesday via Zoom](https://cloudposse.com/office-hours?utm_source=github&utm_medium=readme&utm_campaign=cloudposse-terraform-components/aws-tgw-attachment&utm_content=office_hours) for your weekly dose of insider DevOps trends, AWS news and Terraform insights, all sourced from our SweetOps community, plus a _live Q&A_ that you can’t find anywhere else.
+It's **FREE** for everyone!
+## License
+
+<a href="https://opensource.org/licenses/Apache-2.0"><img src="https://img.shields.io/badge/License-Apache%202.0-blue.svg?style=for-the-badge" alt="License"></a>
+
+<details>
+<summary>Preamble to the Apache License, Version 2.0</summary>
+<br/>
+<br/>
+
+
+
+```text
+Licensed to the Apache Software Foundation (ASF) under one
+or more contributor license agreements.  See the NOTICE file
+distributed with this work for additional information
+regarding copyright ownership.  The ASF licenses this file
+to you under the Apache License, Version 2.0 (the
+"License"); you may not use this file except in compliance
+with the License.  You may obtain a copy of the License at
+
+  https://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing,
+software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+KIND, either express or implied.  See the License for the
+specific language governing permissions and limitations
+under the License.
+```
+</details>
+
+## Trademarks
+
+All other trademarks referenced herein are the property of their respective owners.
+
+
+---
+Copyright © 2017-2025 [Cloud Posse, LLC](https://cpco.io/copyright)
+
+
+<a href="https://cloudposse.com/readme/footer/link?utm_source=github&utm_medium=readme&utm_campaign=cloudposse-terraform-components/aws-tgw-attachment&utm_content=readme_footer_link"><img alt="README footer" src="https://cloudposse.com/readme/footer/img"/></a>
+
+<img alt="Beacon" width="0" src="https://ga-beacon.cloudposse.com/UA-76589703-4/cloudposse-terraform-components/aws-tgw-attachment?pixel&cs=github&cm=readme&an=aws-tgw-attachment"/>

--- a/README.md
+++ b/README.md
@@ -64,7 +64,7 @@ components:
 
 #### Transit Gateway Route Table Association
 
-In the primary account, the account that has the Transit Gateway and the Transit Gateway Route Table, we need to create an association with the Transit Gateway Route Table. This is necessary for attachments in the _same account_ as the Transit Gateway Route Table. For example, if you have a Transit Gateway Route Table in the _core-network_ account, you will need to create an association for each of the VPCs in the _core-network_ account.
+In the primary account, the account that has the Transit Gateway and the Transit Gateway Route Table, we need to create an association with the Transit Gateway Route Table. This is necessary for attachments to connect to the Transit Gateway Route Table. For example, if you have a Transit Gateway Route Table in the _core-network_ account, you will need to create an association for each VPCs connected to that Transit Gateway Route Table.
 
 The intention is to have all configuration for a given account in the same stack as that account. For example, since the Transit Gateway Route Table is in the _core-network_ account, we would create all necessary associations in the _core-network_ account.
 

--- a/README.md
+++ b/README.md
@@ -64,7 +64,7 @@ components:
 
 #### Transit Gateway Route Table Association
 
-If you have a Transit Gateway Route Table, you can create an association with the Transit Gateway VPC Attachment. This is necessary for attachments in the _same account_ as the Transit Gateway Route Table. For example, if you have a Transit Gateway Route Table in the _core_ account, you will need to create an association for each of the VPCs in the _core_ account.
+If you have a Transit Gateway Route Table, you can create an association with the Transit Gateway VPC Attachment. This is necessary for attachments in the _same account_ as the Transit Gateway Route Table. For example, if you have a Transit Gateway Route Table in the _core-network_ account, you will need to create an association for each of the VPCs in the _core-network_ account.
 
 For any connected VPC to this account, you need to create an association with the Transit Gateway Route Table.
 

--- a/README.yaml
+++ b/README.yaml
@@ -25,7 +25,7 @@ usage: |-
 
   #### Transit Gateway Route Table Association
 
-  In the primary account, the account that has the Transit Gateway and the Transit Gateway Route Table, we need to create an association with the Transit Gateway Route Table. This is necessary for attachments in the _same account_ as the Transit Gateway Route Table. For example, if you have a Transit Gateway Route Table in the _core-network_ account, you will need to create an association for each of the VPCs in the _core-network_ account.
+  In the primary account, the account that has the Transit Gateway and the Transit Gateway Route Table, we need to create an association with the Transit Gateway Route Table. This is necessary for attachments to connect to the Transit Gateway Route Table. For example, if you have a Transit Gateway Route Table in the _core-network_ account, you will need to create an association for each VPCs connected to that Transit Gateway Route Table.
 
   The intention is to have all configuration for a given account in the same stack as that account. For example, since the Transit Gateway Route Table is in the _core-network_ account, we would create all necessary associations in the _core-network_ account.
 

--- a/README.yaml
+++ b/README.yaml
@@ -1,23 +1,65 @@
-name: "template"
+name: "aws-tgw-attachment"
 
 # Canonical GitHub repo
-github_repo: "cloudposse-terraform-components/template"
+github_repo: "cloudposse-terraform-components/aws-tgw-attachment"
 
 # Short description of this project
 description: |-
-  Description of this component
+  This component creates a Transit Gateway VPC Attachment and optionally creates an association with a Transit Gateway Route Table.
 
 usage: |-
   **Stack Level**: Regional or Test47
 
   Here's an example snippet for how to use this component.
-  
+
   ```yaml
   components:
     terraform:
-      foo:
+      tgw/attachment:
         vars:
           enabled: true
+          transit_gateway_id: !terraform.output tgw/hub core-use1-network transit_gateway_id
+          transit_gateway_route_table_id: !terraform.output tgw/hub core-use1-network transit_gateway_route_table_id
+          create_transit_gateway_route_table_association: false
+  ```
+
+  #### Transit Gateway Route Table Association
+
+  If you have a Transit Gateway Route Table, you can create an association with the Transit Gateway VPC Attachment. This is necessary for attachments in the _same account_ as the Transit Gateway Route Table. For example, if you have a Transit Gateway Route Table in the _core_ account, you will need to create an association for each of the VPCs in the _core_ account.
+
+  ```yaml
+  # core-network stack
+  components:
+    terraform:
+      tgw/attachment:
+        vars:
+          enabled: true
+          transit_gateway_id: !terraform.output tgw/hub core-use1-network transit_gateway_id
+          transit_gateway_route_table_id: !terraform.output tgw/hub core-use1-network transit_gateway_route_table_id
+          create_transit_gateway_route_table_association: true
+  ```
+
+  #### Additional Associations
+
+  If you have peered connections to other VPCs, you may need to create associations for each of those VPCs. You typically need these associations created in the same account as the peered Transit Gateway.
+
+  ```yaml
+  # core-usw2-network stack (example alternative region)
+  components:
+    terraform:
+      tgw/attachment:
+        vars:
+          enabled: true
+          transit_gateway_id: !terraform.output tgw/hub core-usw2-network transit_gateway_id
+          transit_gateway_route_table_id: !terraform.output tgw/hub core-usw2-network transit_gateway_route_table_id
+          create_transit_gateway_route_table_association: true
+
+          # Add associations for the peered VPCs' Transit Gateway Attachments
+          additional_associations:
+            - attachment_id: !terraform.output tgw/attachment plat-usw2-dev transit_gateway_attachment_id
+              route_table_id: !terraform.output tgw/hub transit_gateway_route_table_id
+            - attachment_id: !terraform.output tgw/attachment plat-usw2-prod transit_gateway_attachment_id
+              route_table_id: !terraform.output tgw/hub transit_gateway_route_table_id
   ```
 
 include:

--- a/README.yaml
+++ b/README.yaml
@@ -8,7 +8,7 @@ description: |-
   This component creates a Transit Gateway VPC Attachment and optionally creates an association with a Transit Gateway Route Table.
 
 usage: |-
-  **Stack Level**: Regional or Test47
+  **Stack Level**: Regional
 
   Here's an example snippet for how to use this component.
 
@@ -25,9 +25,9 @@ usage: |-
 
   #### Transit Gateway Route Table Association
 
-  If you have a Transit Gateway Route Table, you can create an association with the Transit Gateway VPC Attachment. This is necessary for attachments in the _same account_ as the Transit Gateway Route Table. For example, if you have a Transit Gateway Route Table in the _core_ account, you will need to create an association for each of the VPCs in the _core_ account.
+  In the primary account, the account that has the Transit Gateway and the Transit Gateway Route Table, we need to create an association with the Transit Gateway Route Table. This is necessary for attachments in the _same account_ as the Transit Gateway Route Table. For example, if you have a Transit Gateway Route Table in the _core-network_ account, you will need to create an association for each of the VPCs in the _core-network_ account.
 
-  For any connected VPC to this account, you need to create an association with the Transit Gateway Route Table.
+  The intention is to have all configuration for a given account in the same stack as that account. For example, since the Transit Gateway Route Table is in the _core-network_ account, we would create all necessary associations in the _core-network_ account.
 
   ```yaml
   # core-network stack
@@ -38,15 +38,35 @@ usage: |-
           enabled: true
           transit_gateway_id: !terraform.output tgw/hub core-usw2-network transit_gateway_id
           transit_gateway_route_table_id: !terraform.output tgw/hub core-usw2-network transit_gateway_route_table_id
+
+          # Add an association for this account itself
           create_transit_gateway_route_table_association: true
 
-          # Include association for each of the connected account
+          # Include association for each of the connected accounts, if necessary
           additional_associations:
             - attachment_id: !terraform.output tgw/attachment plat-usw2-dev transit_gateway_attachment_id
               route_table_id: !terraform.output tgw/hub transit_gateway_route_table_id
             - attachment_id: !terraform.output tgw/attachment plat-usw2-prod transit_gateway_attachment_id
               route_table_id: !terraform.output tgw/hub transit_gateway_route_table_id
   ```
+
+  In connected accounts, an account that does _not_ have a Transit Gateway and Transit Gateway Route Table, you do not need to create any associations.
+
+  ```yaml
+  # plat-dev stack
+  components:
+    terraform:
+      tgw/attachment:
+        vars:
+          enabled: true
+          transit_gateway_id: !terraform.output tgw/hub core-usw2-network transit_gateway_id
+          transit_gateway_route_table_id: !terraform.output tgw/hub core-usw2-network transit_gateway_route_table_id
+
+          # Do not create an association in this account since there is no Transit Gateway Route Table in this account.
+          create_transit_gateway_route_table_association: false
+  ```
+
+  Plus the same for all other connected accounts.
 
 include:
   - "docs/terraform.md"

--- a/README.yaml
+++ b/README.yaml
@@ -27,24 +27,10 @@ usage: |-
 
   If you have a Transit Gateway Route Table, you can create an association with the Transit Gateway VPC Attachment. This is necessary for attachments in the _same account_ as the Transit Gateway Route Table. For example, if you have a Transit Gateway Route Table in the _core_ account, you will need to create an association for each of the VPCs in the _core_ account.
 
+  For any connected VPC to this account, you need to create an association with the Transit Gateway Route Table.
+
   ```yaml
   # core-network stack
-  components:
-    terraform:
-      tgw/attachment:
-        vars:
-          enabled: true
-          transit_gateway_id: !terraform.output tgw/hub core-use1-network transit_gateway_id
-          transit_gateway_route_table_id: !terraform.output tgw/hub core-use1-network transit_gateway_route_table_id
-          create_transit_gateway_route_table_association: true
-  ```
-
-  #### Additional Associations
-
-  If you have peered connections to other VPCs, you may need to create associations for each of those VPCs. You typically need these associations created in the same account as the peered Transit Gateway.
-
-  ```yaml
-  # core-usw2-network stack (example alternative region)
   components:
     terraform:
       tgw/attachment:
@@ -54,7 +40,7 @@ usage: |-
           transit_gateway_route_table_id: !terraform.output tgw/hub core-usw2-network transit_gateway_route_table_id
           create_transit_gateway_route_table_association: true
 
-          # Add associations for the peered VPCs' Transit Gateway Attachments
+          # Include association for each of the connected account
           additional_associations:
             - attachment_id: !terraform.output tgw/attachment plat-usw2-dev transit_gateway_attachment_id
               route_table_id: !terraform.output tgw/hub transit_gateway_route_table_id

--- a/src/README.md
+++ b/src/README.md
@@ -1,0 +1,207 @@
+---
+tags:
+  - component/tgw/attachment
+  - layer/network
+  - provider/aws
+---
+
+# Component: `tgw/attachment`
+
+This component is responsible for provisioning an AWS Transit Gateway VPC attachment and managing its route table associations. It enables VPCs to connect to a Transit Gateway for inter-VPC communication.
+
+## Usage
+
+**Stack Level**: Regional
+
+This component is deployed to each region where VPCs need to be attached to a Transit Gateway.
+
+### Basic Example
+
+Here's a simple example using physical IDs:
+
+```yaml
+components:
+  terraform:
+    tgw/attachment:
+      vars:
+        transit_gateway_id: "tgw-0123456789abcdef0"
+        transit_gateway_route_table_id: "tgw-rtb-0123456789abcdef0"
+        create_transit_gateway_route_table_association: false
+```
+
+The same configuration using terraform outputs:
+
+```yaml
+components:
+  terraform:
+    tgw/attachment:
+      vars:
+        transit_gateway_id: !terraform.output tgw/hub transit_gateway_id
+        transit_gateway_route_table_id: !terraform.output tgw/hub transit_gateway_route_table_id
+        create_transit_gateway_route_table_association: false
+```
+
+### Network Account Configuration
+
+Example using physical IDs:
+
+```yaml
+components:
+  terraform:
+    tgw/attachment:
+      vars:
+        transit_gateway_id: "tgw-0123456789abcdef0"
+        transit_gateway_route_table_id: "tgw-rtb-0123456789abcdef0"
+        create_transit_gateway_route_table_association: true
+
+        # Additional associations are required for peered connections
+        additional_associations:
+          - attachment_id: "tgw-attach-0123456789abcdef1"
+            route_table_id: "tgw-rtb-0123456789abcdef0"
+```
+
+The same configuration using terraform outputs:
+
+```yaml
+components:
+  terraform:
+    tgw/attachment:
+      vars:
+        transit_gateway_id: !terraform.output tgw/hub transit_gateway_id
+        transit_gateway_route_table_id: !terraform.output tgw/hub transit_gateway_route_table_id
+        create_transit_gateway_route_table_association: true
+
+        # Additional associations are required for peered connections
+        additional_associations:
+          - attachment_id: !terraform.output tgw/attachment edge-vpc transit_gateway_attachment_id
+            route_table_id: !terraform.output tgw/hub transit_gateway_route_table_id
+```
+
+### Multiple Transit Gateway Support
+
+Example using physical IDs:
+
+```yaml
+components:
+  terraform:
+    tgw/attachment/nonprod:
+      metadata:
+        component: tgw/attachment
+      vars:
+        transit_gateway_id: "tgw-0123456789abcdef1"
+        transit_gateway_route_table_id: "tgw-rtb-0123456789abcdef1"
+        create_transit_gateway_route_table_association: false
+
+    tgw/attachment/prod:
+      metadata:
+        component: tgw/attachment
+      vars:
+        transit_gateway_id: "tgw-0123456789abcdef2"
+        transit_gateway_route_table_id: "tgw-rtb-0123456789abcdef2"
+        create_transit_gateway_route_table_association: false
+```
+
+The same configuration using terraform outputs:
+
+```yaml
+components:
+  terraform:
+    tgw/attachment/nonprod:
+      metadata:
+        component: tgw/attachment
+      vars:
+        transit_gateway_id: !terraform.output tgw/hub transit-use1-nonprod transit_gateway_id
+        transit_gateway_route_table_id: !terraform.output tgw/hub transit-use1-nonprod transit_gateway_route_table_id
+        create_transit_gateway_route_table_association: false
+
+    tgw/attachment/prod:
+      metadata:
+        component: tgw/attachment
+      vars:
+        transit_gateway_id: !terraform.output tgw/hub transit-use1-prod transit_gateway_id
+        transit_gateway_route_table_id: !terraform.output tgw/hub transit-use1-prod transit_gateway_route_table_id
+        create_transit_gateway_route_table_association: false
+```
+
+## Important Notes
+
+1. Route table associations (`create_transit_gateway_route_table_association`) should only be enabled in the network account where the Transit Gateway exists.
+
+2. When connecting to multiple Transit Gateways:
+   - Use clear naming conventions (e.g., `tgw/attachment/prod`, `tgw/attachment/nonprod`)
+   - Configure appropriate VPC routes to direct traffic through the correct Transit Gateway
+
+3. After creating attachments, configure VPC routes using the `vpc-routes` component to enable traffic flow.
+
+<!-- prettier-ignore-start -->
+<!-- BEGINNING OF PRE-COMMIT-TERRAFORM DOCS HOOK -->
+## Requirements
+
+| Name | Version |
+|------|---------|
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.0.0 |
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 4.1 |
+
+## Providers
+
+| Name | Version |
+|------|---------|
+| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 4.1 |
+
+## Modules
+
+| Name | Source | Version |
+|------|--------|---------|
+| <a name="module_iam_roles"></a> [iam\_roles](#module\_iam\_roles) | ../../account-map/modules/iam-roles | n/a |
+| <a name="module_standard_vpc_attachment"></a> [standard\_vpc\_attachment](#module\_standard\_vpc\_attachment) | cloudposse/transit-gateway/aws | 0.11.0 |
+| <a name="module_this"></a> [this](#module\_this) | cloudposse/label/null | 0.25.0 |
+| <a name="module_vpc"></a> [vpc](#module\_vpc) | cloudposse/stack-config/yaml//modules/remote-state | 1.5.0 |
+
+## Resources
+
+| Name | Type |
+|------|------|
+| [aws_ec2_transit_gateway_route_table_association.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/ec2_transit_gateway_route_table_association) | resource |
+
+## Inputs
+
+| Name | Description | Type | Default | Required |
+|------|-------------|------|---------|:--------:|
+| <a name="input_additional_associations"></a> [additional\_associations](#input\_additional\_associations) | List of TGW attachments to associate with route tables | <pre>list(object({<br/>    attachment_id  = string<br/>    route_table_id = string<br/>  }))</pre> | `[]` | no |
+| <a name="input_additional_tag_map"></a> [additional\_tag\_map](#input\_additional\_tag\_map) | Additional key-value pairs to add to each map in `tags_as_list_of_maps`. Not added to `tags` or `id`.<br/>This is for some rare cases where resources want additional configuration of tags<br/>and therefore take a list of maps with tag key, value, and additional configuration. | `map(string)` | `{}` | no |
+| <a name="input_attributes"></a> [attributes](#input\_attributes) | ID element. Additional attributes (e.g. `workers` or `cluster`) to add to `id`,<br/>in the order they appear in the list. New attributes are appended to the<br/>end of the list. The elements of the list are joined by the `delimiter`<br/>and treated as a single ID element. | `list(string)` | `[]` | no |
+| <a name="input_context"></a> [context](#input\_context) | Single object for setting entire context at once.<br/>See description of individual variables for details.<br/>Leave string and numeric variables as `null` to use default value.<br/>Individual variable settings (non-null) override settings in context object,<br/>except for attributes, tags, and additional\_tag\_map, which are merged. | `any` | <pre>{<br/>  "additional_tag_map": {},<br/>  "attributes": [],<br/>  "delimiter": null,<br/>  "descriptor_formats": {},<br/>  "enabled": true,<br/>  "environment": null,<br/>  "id_length_limit": null,<br/>  "label_key_case": null,<br/>  "label_order": [],<br/>  "label_value_case": null,<br/>  "labels_as_tags": [<br/>    "unset"<br/>  ],<br/>  "name": null,<br/>  "namespace": null,<br/>  "regex_replace_chars": null,<br/>  "stage": null,<br/>  "tags": {},<br/>  "tenant": null<br/>}</pre> | no |
+| <a name="input_create_transit_gateway_route_table_association"></a> [create\_transit\_gateway\_route\_table\_association](#input\_create\_transit\_gateway\_route\_table\_association) | Whether to create the Transit Gateway Route Table Association | `bool` | `true` | no |
+| <a name="input_delimiter"></a> [delimiter](#input\_delimiter) | Delimiter to be used between ID elements.<br/>Defaults to `-` (hyphen). Set to `""` to use no delimiter at all. | `string` | `null` | no |
+| <a name="input_descriptor_formats"></a> [descriptor\_formats](#input\_descriptor\_formats) | Describe additional descriptors to be output in the `descriptors` output map.<br/>Map of maps. Keys are names of descriptors. Values are maps of the form<br/>`{<br/>   format = string<br/>   labels = list(string)<br/>}`<br/>(Type is `any` so the map values can later be enhanced to provide additional options.)<br/>`format` is a Terraform format string to be passed to the `format()` function.<br/>`labels` is a list of labels, in order, to pass to `format()` function.<br/>Label values will be normalized before being passed to `format()` so they will be<br/>identical to how they appear in `id`.<br/>Default is `{}` (`descriptors` output will be empty). | `any` | `{}` | no |
+| <a name="input_enabled"></a> [enabled](#input\_enabled) | Set to false to prevent the module from creating any resources | `bool` | `null` | no |
+| <a name="input_environment"></a> [environment](#input\_environment) | ID element. Usually used for region e.g. 'uw2', 'us-west-2', OR role 'prod', 'staging', 'dev', 'UAT' | `string` | `null` | no |
+| <a name="input_id_length_limit"></a> [id\_length\_limit](#input\_id\_length\_limit) | Limit `id` to this many characters (minimum 6).<br/>Set to `0` for unlimited length.<br/>Set to `null` for keep the existing setting, which defaults to `0`.<br/>Does not affect `id_full`. | `number` | `null` | no |
+| <a name="input_label_key_case"></a> [label\_key\_case](#input\_label\_key\_case) | Controls the letter case of the `tags` keys (label names) for tags generated by this module.<br/>Does not affect keys of tags passed in via the `tags` input.<br/>Possible values: `lower`, `title`, `upper`.<br/>Default value: `title`. | `string` | `null` | no |
+| <a name="input_label_order"></a> [label\_order](#input\_label\_order) | The order in which the labels (ID elements) appear in the `id`.<br/>Defaults to ["namespace", "environment", "stage", "name", "attributes"].<br/>You can omit any of the 6 labels ("tenant" is the 6th), but at least one must be present. | `list(string)` | `null` | no |
+| <a name="input_label_value_case"></a> [label\_value\_case](#input\_label\_value\_case) | Controls the letter case of ID elements (labels) as included in `id`,<br/>set as tag values, and output by this module individually.<br/>Does not affect values of tags passed in via the `tags` input.<br/>Possible values: `lower`, `title`, `upper` and `none` (no transformation).<br/>Set this to `title` and set `delimiter` to `""` to yield Pascal Case IDs.<br/>Default value: `lower`. | `string` | `null` | no |
+| <a name="input_labels_as_tags"></a> [labels\_as\_tags](#input\_labels\_as\_tags) | Set of labels (ID elements) to include as tags in the `tags` output.<br/>Default is to include all labels.<br/>Tags with empty values will not be included in the `tags` output.<br/>Set to `[]` to suppress all generated tags.<br/>**Notes:**<br/>  The value of the `name` tag, if included, will be the `id`, not the `name`.<br/>  Unlike other `null-label` inputs, the initial setting of `labels_as_tags` cannot be<br/>  changed in later chained modules. Attempts to change it will be silently ignored. | `set(string)` | <pre>[<br/>  "default"<br/>]</pre> | no |
+| <a name="input_name"></a> [name](#input\_name) | ID element. Usually the component or solution name, e.g. 'app' or 'jenkins'.<br/>This is the only ID element not also included as a `tag`.<br/>The "name" tag is set to the full `id` string. There is no tag with the value of the `name` input. | `string` | `null` | no |
+| <a name="input_namespace"></a> [namespace](#input\_namespace) | ID element. Usually an abbreviation of your organization name, e.g. 'eg' or 'cp', to help ensure generated IDs are globally unique | `string` | `null` | no |
+| <a name="input_regex_replace_chars"></a> [regex\_replace\_chars](#input\_regex\_replace\_chars) | Terraform regular expression (regex) string.<br/>Characters matching the regex will be removed from the ID elements.<br/>If not set, `"/[^a-zA-Z0-9-]/"` is used to remove all characters other than hyphens, letters and digits. | `string` | `null` | no |
+| <a name="input_region"></a> [region](#input\_region) | AWS Region | `string` | n/a | yes |
+| <a name="input_stage"></a> [stage](#input\_stage) | ID element. Usually used to indicate role, e.g. 'prod', 'staging', 'source', 'build', 'test', 'deploy', 'release' | `string` | `null` | no |
+| <a name="input_tags"></a> [tags](#input\_tags) | Additional tags (e.g. `{'BusinessUnit': 'XYZ'}`).<br/>Neither the tag keys nor the tag values will be modified by this module. | `map(string)` | `{}` | no |
+| <a name="input_tenant"></a> [tenant](#input\_tenant) | ID element \_(Rarely used, not included by default)\_. A customer identifier, indicating who this instance of a resource is for | `string` | `null` | no |
+| <a name="input_transit_gateway_id"></a> [transit\_gateway\_id](#input\_transit\_gateway\_id) | ID of the Transit Gateway to attach to | `string` | n/a | yes |
+| <a name="input_transit_gateway_route_table_id"></a> [transit\_gateway\_route\_table\_id](#input\_transit\_gateway\_route\_table\_id) | ID of the Transit Gateway Route Table | `string` | n/a | yes |
+
+## Outputs
+
+| Name | Description |
+|------|-------------|
+| <a name="output_transit_gateway_vpc_attachment_id"></a> [transit\_gateway\_vpc\_attachment\_id](#output\_transit\_gateway\_vpc\_attachment\_id) | ID of the Transit Gateway VPC Attachment |
+<!-- END OF PRE-COMMIT-TERRAFORM DOCS HOOK -->
+<!-- prettier-ignore-end -->
+
+## References
+
+- [AWS Transit Gateway Documentation](https://docs.aws.amazon.com/vpc/latest/tgw/what-is-transit-gateway.html)
+- [cloudposse/terraform-aws-components](TODO) - Cloud Posse's upstream component
+
+[<img src="https://cloudposse.com/logo-300x69.svg" height="32" align="right"/>](https://cpco.io/component)

--- a/src/main.tf
+++ b/src/main.tf
@@ -1,8 +1,49 @@
-locals {
-  enabled = module.this.enabled
+# Create a TGW attachment from this account's VPC to the TGW Hub
+module "standard_vpc_attachment" {
+  source  = "cloudposse/transit-gateway/aws"
+  version = "0.11.0"
+
+  existing_transit_gateway_id             = var.transit_gateway_id
+  existing_transit_gateway_route_table_id = var.transit_gateway_route_table_id
+
+  route_keys_enabled                                             = false
+  create_transit_gateway                                         = false
+  create_transit_gateway_route_table                             = false
+  create_transit_gateway_vpc_attachment                          = true
+  create_transit_gateway_route_table_association_and_propagation = false
+
+  config = {
+    "this" = {
+      vpc_id                            = module.vpc.outputs.vpc_id
+      subnet_ids                        = module.vpc.outputs.private_subnet_ids
+      route_to                          = []
+      route_to_cidr_blocks              = []
+      static_routes                     = []
+      subnet_route_table_ids            = []
+      transit_gateway_vpc_attachment_id = null
+      vpc_cidr                          = null
+    }
+  }
+
+  context = module.this.context
 }
 
+locals {
+  # Combine external associations with local VPC attachment if enabled
+  associations = var.create_transit_gateway_route_table_association ? concat([
+    {
+      attachment_id  = module.standard_vpc_attachment.transit_gateway_vpc_attachment_ids["this"]
+      route_table_id = var.transit_gateway_route_table_id
+    }
+  ], var.additional_associations) : var.additional_associations
+}
 
+# We need to create the association for each of the connected SDLC accounts and for this account itself
+resource "aws_ec2_transit_gateway_route_table_association" "this" {
+  for_each = module.this.enabled ? {
+    for assoc in local.associations : assoc.attachment_id => assoc
+  } : {}
 
-
-
+  transit_gateway_attachment_id  = each.key
+  transit_gateway_route_table_id = each.value.route_table_id
+}

--- a/src/outputs.tf
+++ b/src/outputs.tf
@@ -1,4 +1,4 @@
-output "mock" {
-  description = "Mock output example for the Cloud Posse Terraform component template"
-  value       = local.enabled ? "hello ${basename(abspath(path.module))}" : ""
+output "transit_gateway_vpc_attachment_id" {
+  value       = module.standard_vpc_attachment.transit_gateway_vpc_attachment_ids["this"]
+  description = "ID of the Transit Gateway VPC Attachment"
 }

--- a/src/providers.tf
+++ b/src/providers.tf
@@ -1,0 +1,19 @@
+provider "aws" {
+  region = var.region
+
+  # Profile is deprecated in favor of terraform_role_arn. When profiles are not in use, terraform_profile_name is null.
+  profile = module.iam_roles.terraform_profile_name
+
+  dynamic "assume_role" {
+    # module.iam_roles.terraform_role_arn may be null, in which case do not assume a role.
+    for_each = compact([module.iam_roles.terraform_role_arn])
+    content {
+      role_arn = assume_role.value
+    }
+  }
+}
+
+module "iam_roles" {
+  source  = "../../account-map/modules/iam-roles"
+  context = module.this.context
+}

--- a/src/remote-state.tf
+++ b/src/remote-state.tf
@@ -1,0 +1,8 @@
+module "vpc" {
+  source  = "cloudposse/stack-config/yaml//modules/remote-state"
+  version = "1.5.0"
+
+  component = "vpc"
+
+  context = module.this.context
+}

--- a/src/variables.tf
+++ b/src/variables.tf
@@ -1,0 +1,29 @@
+variable "region" {
+  type        = string
+  description = "AWS Region"
+}
+
+variable "transit_gateway_id" {
+  type        = string
+  description = "ID of the Transit Gateway to attach to"
+}
+
+variable "transit_gateway_route_table_id" {
+  type        = string
+  description = "ID of the Transit Gateway Route Table"
+}
+
+variable "create_transit_gateway_route_table_association" {
+  type        = bool
+  description = "Whether to create the Transit Gateway Route Table Association"
+  default     = true
+}
+
+variable "additional_associations" {
+  type = list(object({
+    attachment_id  = string
+    route_table_id = string
+  }))
+  description = "List of TGW attachments to associate with route tables"
+  default     = []
+}

--- a/src/versions.tf
+++ b/src/versions.tf
@@ -1,5 +1,10 @@
 terraform {
   required_version = ">= 1.0.0"
 
-  required_providers {}
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = ">= 4.1"
+    }
+  }
 }


### PR DESCRIPTION
## what
- Upstream initial implementation
- `aws-tgw-hub`, `aws-tgw-routes`, `aws-tgw-attachment`, `aws-vpc-routes` are very closely tied together. Creating all now

## why
- We do not have the public documentation for docs.cloudposse ready yet, but we want to make what we do have available
- These improvements have come up in discussion more than once, so let's push it up

## references
- https://github.com/orgs/cloudposse/discussions/31

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

- **New Features**
	- Added a new component for AWS Transit Gateway VPC Attachment.
	- Introduced configuration for creating Transit Gateway Route Table associations.

- **Documentation**
	- Updated README with detailed usage examples and component descriptions.
	- Enhanced documentation for Transit Gateway attachment configurations.
	- Revised README.yaml to reflect new naming and descriptions.
	- Updated project banner and links in README.

- **Chores**
	- Updated project configuration files.
	- Refined Terraform provider and version specifications.
	- Updated pre-commit hook configurations.

- **Technical Improvements**
	- Added new variables for flexible Transit Gateway attachment management.
	- Implemented dynamic provider and role assumption configurations.
	- Enhanced build process by modifying Makefile dependencies.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->