### PR TITLE
Rollback providers constraints

### DIFF
--- a/src/versions.tf
+++ b/src/versions.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "< 7.0.0"
+      version = ">= 4.1, < 6.0.0"
     }
   }
 }


### PR DESCRIPTION
## what
* Rollback providers' constraints

## why
* The component had `published: false` property, so it bypassed the requirements constraints and got some wrong PRs merged

## references
* #20 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the AWS provider version requirements for Terraform to allow versions between 4.1 (inclusive) and 6.0.0 (exclusive).

<!-- end of auto-generated comment: release notes by coderabbit.ai -->