### PR TITLE
Allow users to set component names in remote state

### DIFF
--- a/src/remote-state.tf
+++ b/src/remote-state.tf
@@ -2,7 +2,7 @@ module "vpc" {
   source  = "cloudposse/stack-config/yaml//modules/remote-state"
   version = "1.8.0"
 
-  component = "vpc"
+  component = var.vpc_component_name
 
   context = module.this.context
 }

--- a/src/variables.tf
+++ b/src/variables.tf
@@ -12,3 +12,9 @@ variable "transit_gateway_route_table_id" {
   type        = string
   description = "ID of the Transit Gateway Route Table"
 }
+
+variable "vpc_component_name" {
+  type        = string
+  description = "The name of the vpc component"
+  default     = "vpc"
+}


### PR DESCRIPTION
Allow users to set component names in remote state.

* Defined the input variable `vpc_component_name`.
* Variable defaults to preserving the behavior of the current version.
* Remote state uses this variable to pull in the state of the components.
* This update allows the codebase to adopt more standardized structure and naming practices.
