### PR TITLE
Use atmos instead of makefile

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,7 @@ aws-assumed-role/
 *.iml
 .direnv
 .envrc
+.atmos
 
 # Compiled and auto-generated files
 # Note that the leading "**/" appears necessary for Docker even if not for Git

--- a/Makefile
+++ b/Makefile
@@ -1,8 +1,0 @@
--include $(shell curl -sSL -o .build-harness "https://cloudposse.tools/build-harness"; echo .build-harness)
-
-all: init docs/terraform.md readme
-
-test::
-	@echo "🚀 Starting tests..."
-	./test/run.sh
-	@echo "✅ All tests passed."

--- a/README.yaml
+++ b/README.yaml
@@ -68,8 +68,7 @@ usage: |-
 
   Plus the same for all other connected accounts.
 
-include:
-  - "docs/terraform.md"
+include: []
 
 tags:
   - terraform

--- a/atmos.yaml
+++ b/atmos.yaml
@@ -1,0 +1,11 @@
+# Atmos Configuration — powered by https://atmos.tools
+#
+# This configuration enables centralized, DRY, and consistent project scaffolding using Atmos.
+#
+# Included features:
+# - Organizational custom commands: https://atmos.tools/core-concepts/custom-commands
+# - Automated README generation: https://atmos.tools/cli/commands/docs/generate
+#
+# Import shared configuration used by all modules
+import:
+  - https://raw.githubusercontent.com/cloudposse-terraform-components/.github/refs/heads/main/.github/atmos/terraform-component.yaml


### PR DESCRIPTION
## what
* Use atmos instead of makefile

## why
* build-harness deprecated. Use atmos instead 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Introduced centralized project configuration to standardize workflows, enable shared commands, and support automated README generation.
- Chores
  - Removed legacy build/test harness and associated targets to streamline maintenance.
  - Simplified documentation configuration by clearing unused includes.
  - Expanded ignore rules to exclude repository-level metadata from version control.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->