### PR TITLE
feat: Pass VPC and Subnet IDs as Inputs

### DIFF
--- a/src/remote-state.tf
+++ b/src/remote-state.tf
@@ -4,5 +4,13 @@ module "vpc" {
 
   component = var.vpc_component_name
 
+  # You can pass the VPC and private subnet IDs directly as inputs to the component to bypass the remote state lookup.
+  # Use this with Atmos functions to dynamically set the VPC and private subnet IDs with custom logic.
+  bypass = var.vpc_id != null
+  defaults = {
+    vpc_id             = var.vpc_id
+    private_subnet_ids = var.private_subnet_ids
+  }
+
   context = module.this.context
 }

--- a/src/variables.tf
+++ b/src/variables.tf
@@ -18,3 +18,15 @@ variable "vpc_component_name" {
   description = "The name of the vpc component"
   default     = "vpc"
 }
+
+variable "vpc_id" {
+  type        = string
+  description = "ID of the VPC to attach to"
+  default     = null
+}
+
+variable "private_subnet_ids" {
+  type        = list(string)
+  description = "IDs of the private subnets to attach to. Required if `vpc_id` is defined."
+  default     = []
+}


### PR DESCRIPTION
## what
- Add support for passing VPC and subnet IDs directly

## why
- We can use `!terraform.state` or atmos functions to provide these values dynamically

## references
. 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added configuration to connect to an existing VPC by providing a VPC ID and private subnet IDs directly.
  * When these values are supplied, the module bypasses remote state lookup and uses the provided IDs.
  * Validation ensures subnet IDs are supplied when a VPC ID is set.
  * Backward compatible: defaults preserve previous behavior if no IDs are provided.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->